### PR TITLE
[23-09-08] kyuhyun

### DIFF
--- a/src/main/java/com/Bridge/bridge/controller/UserController.java
+++ b/src/main/java/com/Bridge/bridge/controller/UserController.java
@@ -1,0 +1,40 @@
+package com.Bridge.bridge.controller;
+
+import com.Bridge.bridge.dto.request.UserRegisterRequest;
+import com.Bridge.bridge.dto.request.UserSignUpRequest;
+import com.Bridge.bridge.dto.response.UserSignUpResponse;
+import com.Bridge.bridge.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    /**
+     * 회원 가입시 유저 이름 등록
+     */
+    @PostMapping("/signup/name")
+    public ResponseEntity<UserSignUpResponse> signUp(@RequestBody @Valid UserSignUpRequest request) {
+        UserSignUpResponse response = userService.signUpName(request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 회원 가입시 관심 분야 등록
+     */
+    @PostMapping("/signup/info")
+    public ResponseEntity saveField(@RequestBody UserRegisterRequest request) {
+        userService.signUpInfo(request);
+        return new ResponseEntity(HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/Bridge/bridge/domain/Field.java
+++ b/src/main/java/com/Bridge/bridge/domain/Field.java
@@ -2,14 +2,22 @@ package com.Bridge.bridge.domain;
 
 import lombok.Getter;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
 @Entity
 @Getter
 public class Field {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "field_id")
+    private Long id;
 
     private String fieldName; // 관심 분야
 

--- a/src/main/java/com/Bridge/bridge/domain/Field.java
+++ b/src/main/java/com/Bridge/bridge/domain/Field.java
@@ -1,0 +1,19 @@
+package com.Bridge.bridge.domain;
+
+import lombok.Getter;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Entity
+@Getter
+public class Field {
+
+    private String fieldName; // 관심 분야
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/src/main/java/com/Bridge/bridge/domain/Field.java
+++ b/src/main/java/com/Bridge/bridge/domain/Field.java
@@ -1,6 +1,7 @@
 package com.Bridge.bridge.domain;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -13,6 +14,7 @@ import javax.persistence.ManyToOne;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class Field {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,7 +23,16 @@ public class Field {
 
     private String fieldName; // 관심 분야
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    public Field(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    //-- 연관관계 메소드 --//
+    public void updateFieldUser(User user) {
+        this.user = user;
+    }
 }

--- a/src/main/java/com/Bridge/bridge/domain/Profile.java
+++ b/src/main/java/com/Bridge/bridge/domain/Profile.java
@@ -1,5 +1,6 @@
 package com.Bridge.bridge.domain;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,8 +17,6 @@ public class Profile {
     @Column(name = "profile_id")
     private Long id;
 
-    private String skill;           // 기술 스택
-
     private String refLink;         // 참고 링크
 
     private String refFile;         // 첨부 파일
@@ -25,6 +24,9 @@ public class Profile {
     private String selfIntro;       // 자기소개서
 
     private String career;          // 경력 사항
+
+    @ElementCollection
+    private List<String> skill;           // 기술 스택
 
     @OneToOne(mappedBy = "profile")
     private User user;              // 해당 프로필을 작성한 유저

--- a/src/main/java/com/Bridge/bridge/domain/Profile.java
+++ b/src/main/java/com/Bridge/bridge/domain/Profile.java
@@ -33,4 +33,15 @@ public class Profile {
 
     @OneToMany(mappedBy = "profile")
     private List<File> files = new ArrayList<>();
+
+    @Builder
+    public Profile(String selfIntro, String career, List<String> skill) {
+        this.selfIntro = selfIntro;
+        this.career = career;
+        this.skill = skill;
+    }
+
+    public void updateUser(User user) {
+        this.user = user;
+    }
 }

--- a/src/main/java/com/Bridge/bridge/domain/User.java
+++ b/src/main/java/com/Bridge/bridge/domain/User.java
@@ -27,7 +27,7 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Field> fields = new ArrayList<>(); // 관심 분야
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "profile_id")
     private Profile profile;            // 개인 프로필
 
@@ -58,5 +58,15 @@ public class User {
     public User(String email, String platformId) {
         this.email = email;
         this.platformId = platformId;
+    }
+
+    public void registerName(String name) {
+        this.name = name;
+    }
+
+    //-- 연관관계 편의 메소드 --//
+    public void updateProfile(Profile profile) {
+        this.profile = profile;
+        profile.updateUser(this);
     }
 }

--- a/src/main/java/com/Bridge/bridge/domain/User.java
+++ b/src/main/java/com/Bridge/bridge/domain/User.java
@@ -24,6 +24,9 @@ public class User {
 
     private String platformId;          // 소셜 로그인 고유 아이디
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Field> fields = new ArrayList<>(); // 관심 분야
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "profile_id")
     private Profile profile;            // 개인 프로필

--- a/src/main/java/com/Bridge/bridge/dto/request/UserFieldRequest.java
+++ b/src/main/java/com/Bridge/bridge/dto/request/UserFieldRequest.java
@@ -1,0 +1,25 @@
+package com.Bridge.bridge.dto.request;
+
+import com.Bridge.bridge.domain.Field;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserFieldRequest {
+
+    private List<String> fieldName;
+
+    public List<Field> toEntity() {
+        return fieldName.stream()
+                .map(Field::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/Bridge/bridge/dto/request/UserProfileRequest.java
+++ b/src/main/java/com/Bridge/bridge/dto/request/UserProfileRequest.java
@@ -1,0 +1,34 @@
+package com.Bridge.bridge.dto.request;
+
+import com.Bridge.bridge.domain.Profile;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+@Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserProfileRequest {
+
+    private String selfIntro;       // 자기소개서
+
+    private String career;          // 경력 사항
+
+    private List<String> stack;     // 스택
+
+    @Builder
+    public UserProfileRequest(String selfIntro, String career, List<String> stack) {
+        this.selfIntro = selfIntro;
+        this.career = career;
+        this.stack = stack;
+    }
+
+    public Profile toEntity() {
+        return Profile.builder()
+                .selfIntro(selfIntro)
+                .career(career)
+                .skill(stack)
+                .build();
+    }
+}

--- a/src/main/java/com/Bridge/bridge/dto/request/UserRegisterRequest.java
+++ b/src/main/java/com/Bridge/bridge/dto/request/UserRegisterRequest.java
@@ -1,0 +1,24 @@
+package com.Bridge.bridge.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserRegisterRequest {
+
+    private Long userId;
+
+    private UserFieldRequest userField;
+
+    private UserProfileRequest userProfile;
+
+    @Builder
+    public UserRegisterRequest(Long userId, UserFieldRequest userField, UserProfileRequest userProfile) {
+        this.userId = userId;
+        this.userField = userField;
+        this.userProfile = userProfile;
+    }
+}

--- a/src/main/java/com/Bridge/bridge/dto/request/UserSignUpRequest.java
+++ b/src/main/java/com/Bridge/bridge/dto/request/UserSignUpRequest.java
@@ -1,0 +1,21 @@
+package com.Bridge.bridge.dto.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Data
+public class UserSignUpRequest {
+
+    @NotBlank
+    private String platformId;
+
+    @NotBlank(message = "이름을 입력해주세요.")
+    private String name;
+
+}

--- a/src/main/java/com/Bridge/bridge/dto/response/UserSignUpResponse.java
+++ b/src/main/java/com/Bridge/bridge/dto/response/UserSignUpResponse.java
@@ -1,0 +1,11 @@
+package com.Bridge.bridge.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class UserSignUpResponse {
+
+    private Long userId;
+}

--- a/src/main/java/com/Bridge/bridge/dto/response/apple/AppleResponse.java
+++ b/src/main/java/com/Bridge/bridge/dto/response/apple/AppleResponse.java
@@ -4,6 +4,9 @@ import lombok.Data;
 
 @Data
 public class AppleResponse {
+
+    private String name;
+
     private String code;
 
     private String idToken;

--- a/src/main/java/com/Bridge/bridge/security/apple/ApplePublicKey.java
+++ b/src/main/java/com/Bridge/bridge/security/apple/ApplePublicKey.java
@@ -1,8 +1,12 @@
 package com.Bridge.bridge.security.apple;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class ApplePublicKey {
 
     private String kty;

--- a/src/main/java/com/Bridge/bridge/security/apple/ApplePublicKeys.java
+++ b/src/main/java/com/Bridge/bridge/security/apple/ApplePublicKeys.java
@@ -2,7 +2,6 @@ package com.Bridge.bridge.security.apple;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/Bridge/bridge/security/apple/ApplePublicKeys.java
+++ b/src/main/java/com/Bridge/bridge/security/apple/ApplePublicKeys.java
@@ -1,12 +1,22 @@
 package com.Bridge.bridge.security.apple;
 
+import lombok.AccessLevel;
 import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
-@Data
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ApplePublicKeys {
 
     private List<ApplePublicKey> keys;
 
+    public ApplePublicKey getMatchesKey(String alg, String kid) {
+        return keys.stream()
+                .filter(k -> k.getAlg().equals(alg) && k.getKid().equals(kid))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Apple JWT 값의 alg, kid 정보가 올바르지 않습니다."));
+    }
 }

--- a/src/main/java/com/Bridge/bridge/security/apple/ApplePublicKeys.java
+++ b/src/main/java/com/Bridge/bridge/security/apple/ApplePublicKeys.java
@@ -1,6 +1,7 @@
 package com.Bridge.bridge.security.apple;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,6 +10,7 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class ApplePublicKeys {
 
     private List<ApplePublicKey> keys;

--- a/src/main/java/com/Bridge/bridge/security/apple/AppleToken.java
+++ b/src/main/java/com/Bridge/bridge/security/apple/AppleToken.java
@@ -30,7 +30,7 @@ public class AppleToken {
 
     private final AppleUtils appleUtils;
 
-    public AppleTokenResponse getAccessToken(String code) throws Exception {
+    public AppleTokenResponse getAccessToken(String code)  {
         RestTemplate rt = new RestTemplate();
 
         HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/Bridge/bridge/security/apple/AppleUtils.java
+++ b/src/main/java/com/Bridge/bridge/security/apple/AppleUtils.java
@@ -70,7 +70,7 @@ public class AppleUtils {
         ApplePublicKeys applePublicKeys = getPublicKey();
         PublicKey publicKey = generatePublicKeys(headers, applePublicKeys);
 
-        Claims claims = passePublicKeyAndGetClaims(idToken, publicKey);
+        Claims claims = parsePublicKeyAndGetClaims(idToken, publicKey);
         if (!validateClaims(claims)) {
             throw new Exception("Claim 값이 올바르지 않음");
         }
@@ -106,7 +106,7 @@ public class AppleUtils {
      * @param idToken
      * @param publicKey
      */
-    public Claims passePublicKeyAndGetClaims(String idToken, PublicKey publicKey) throws Exception {
+    public Claims parsePublicKeyAndGetClaims(String idToken, PublicKey publicKey) throws Exception {
         try {
             return Jwts.parser()
                     .setSigningKey(publicKey)

--- a/src/main/java/com/Bridge/bridge/security/apple/AppleUtils.java
+++ b/src/main/java/com/Bridge/bridge/security/apple/AppleUtils.java
@@ -82,7 +82,7 @@ public class AppleUtils {
      * payload 검증 메소드
      * @param claims
      */
-    private boolean validateClaims(Claims claims) {
+    public boolean validateClaims(Claims claims) {
         return claims.getIssuer().contains(APPLE_ISS) &&
                 claims.getAudience().equals(APPLE_CLIENT_ID);
     }
@@ -91,7 +91,7 @@ public class AppleUtils {
      * ID Token 헤더 디코딩 메소드
      * @param idToken
      */
-    private Map<String, String> parseHeaders(String idToken) throws IllegalAccessException {
+    public Map<String, String> parseHeaders(String idToken) throws IllegalAccessException {
         try {
             String encodedHeader = idToken.split("\\.")[0];
             String decodedHeader = new String(Base64Utils.decodeFromUrlSafeString(encodedHeader));
@@ -106,7 +106,7 @@ public class AppleUtils {
      * @param idToken
      * @param publicKey
      */
-    private Claims passePublicKeyAndGetClaims(String idToken, PublicKey publicKey) throws Exception {
+    public Claims passePublicKeyAndGetClaims(String idToken, PublicKey publicKey) throws Exception {
         try {
             return Jwts.parser()
                     .setSigningKey(publicKey)
@@ -155,7 +155,7 @@ public class AppleUtils {
      * @param header
      * @param keys
      */
-    private PublicKey generatePublicKeys(Map<String, String> header, ApplePublicKeys keys) throws Exception {
+    public PublicKey generatePublicKeys(Map<String, String> header, ApplePublicKeys keys) throws Exception {
         ApplePublicKey publicKey = keys.getMatchesKey(header.get("alg"), header.get("kid"));
 
         byte[] nBytes = Base64Utils.decodeFromUrlSafeString(publicKey.getN());

--- a/src/main/java/com/Bridge/bridge/security/apple/AppleUtils.java
+++ b/src/main/java/com/Bridge/bridge/security/apple/AppleUtils.java
@@ -23,6 +23,7 @@ import org.springframework.web.client.RestTemplate;
 
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.math.BigInteger;
@@ -178,7 +179,7 @@ public class AppleUtils {
     /**
      * acceseToken을 얻기 위해 필요한 Client_Secret 생성
      */
-    public String createClientSecret() throws Exception {
+    public String createClientSecret() {
         JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(APPLE_KEY_ID).build();
         Date now = new Date();
         Date expiration = new Date(now.getTime() + 3600000);
@@ -198,18 +199,24 @@ public class AppleUtils {
     /**
      * 비밀키 파일 읽어오기
      */
-    private PrivateKey getPrivateKey() throws Exception {
-        InputStream privateKey = new ClassPathResource(APPLE_KEY_PATH).getInputStream();
+    private PrivateKey getPrivateKey() {
+        try {
+            InputStream privateKey = new ClassPathResource(APPLE_KEY_PATH).getInputStream();
 
-        String result = new BufferedReader(new InputStreamReader(privateKey)) .lines().collect(Collectors.joining("\n"));
+            String result = new BufferedReader(new InputStreamReader(privateKey)) .lines().collect(Collectors.joining("\n"));
 
-        String key = result.replace("-----BEGIN PRIVATE KEY-----\n", "")
-                .replace("-----END PRIVATE KEY-----", "");
+            String key = result.replace("-----BEGIN PRIVATE KEY-----\n", "")
+                    .replace("-----END PRIVATE KEY-----", "");
 
-        byte[] encoded = Base64.decodeBase64(key);
+            byte[] encoded = Base64.decodeBase64(key);
 
-        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(encoded);
-        KeyFactory keyFactory = KeyFactory.getInstance("EC");
-        return keyFactory.generatePrivate(keySpec);
+            PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(encoded);
+            KeyFactory keyFactory = null;
+            keyFactory = KeyFactory.getInstance("EC");
+
+            return keyFactory.generatePrivate(keySpec);
+        } catch (IOException | NoSuchAlgorithmException | InvalidKeySpecException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/com/Bridge/bridge/security/apple/AppleUtils.java
+++ b/src/main/java/com/Bridge/bridge/security/apple/AppleUtils.java
@@ -57,21 +57,8 @@ public class AppleUtils {
     @Value("${apple.iss}")
     private String APPLE_ISS;
 
-    private final static String APPLE_AUTH_URL = "https://appleid.apple.com/auth/authorize";
-
     private final ObjectMapper objectMapper;
 
-
-    /**
-     * 처음 로그인 시 애플로그인으로 이동할 수 있게 하는 URL
-     * @return : apple 로그인 URL 반환
-     */
-    public String getAppleLogin() {
-        return APPLE_AUTH_URL
-                + "?client_id=" + APPLE_CLIENT_ID
-                + "&redirect_uri=" + APPLE_REDIRECT_URL
-                + "&response_type=code%20id_token&scope=name%20email&response_mode=form_post";
-    }
 
     /**
      * ID Token 검증 후 유저 정보 가져오는 메소드

--- a/src/main/java/com/Bridge/bridge/security/apple/AppleUtils.java
+++ b/src/main/java/com/Bridge/bridge/security/apple/AppleUtils.java
@@ -156,10 +156,7 @@ public class AppleUtils {
      * @param keys
      */
     private PublicKey generatePublicKeys(Map<String, String> header, ApplePublicKeys keys) throws Exception {
-        ApplePublicKey publicKey = keys.getKeys().stream()
-                .filter(k -> k.getAlg().equals(header.get("alg")) && k.getKid().equals(header.get("kid")))
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Apple JWT 값의 alg, kid 정보가 올바르지 않습니다."));
+        ApplePublicKey publicKey = keys.getMatchesKey(header.get("alg"), header.get("kid"));
 
         byte[] nBytes = Base64Utils.decodeFromUrlSafeString(publicKey.getN());
         byte[] eBytes = Base64Utils.decodeFromUrlSafeString(publicKey.getE());

--- a/src/main/java/com/Bridge/bridge/service/UserService.java
+++ b/src/main/java/com/Bridge/bridge/service/UserService.java
@@ -1,0 +1,79 @@
+package com.Bridge.bridge.service;
+
+import com.Bridge.bridge.domain.Field;
+import com.Bridge.bridge.domain.Profile;
+import com.Bridge.bridge.domain.User;
+import com.Bridge.bridge.dto.request.UserFieldRequest;
+import com.Bridge.bridge.dto.request.UserProfileRequest;
+import com.Bridge.bridge.dto.request.UserRegisterRequest;
+import com.Bridge.bridge.dto.request.UserSignUpRequest;
+import com.Bridge.bridge.dto.response.UserSignUpResponse;
+import com.Bridge.bridge.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 처음 로그인 시 이름 정보 등록
+     */
+    @Transactional
+    public UserSignUpResponse signUpName(UserSignUpRequest request) {
+        User findUser = userRepository.findByPlatformId(request.getPlatformId())
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 유저입니다."));
+
+        findUser.registerName(request.getName());
+        return new UserSignUpResponse(findUser.getId());
+    }
+
+    public void signUpInfo(UserRegisterRequest request) {
+        saveField(request.getUserId(), request.getUserField());
+        saveProfile(request.getUserId(), request.getUserProfile());
+    }
+
+    /**
+     * 처음 로그인 시 개인 관심분야 등록
+     */
+    @Transactional
+    public boolean saveField(Long userId, UserFieldRequest request) {
+        if(Objects.isNull(request)) {
+            return false;
+        }
+        User findUser = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 유저입니다."));
+
+        List<Field> fields = request.toEntity();
+        fields.stream()
+                .forEach(f -> f.updateFieldUser(findUser));
+
+        findUser.getFields().addAll(fields);
+        return true;
+    }
+
+    /**
+     * 처음 로그인 시 개인 프로필 등록
+     */
+    @Transactional
+    public boolean saveProfile(Long userId, UserProfileRequest request) {
+        if (Objects.isNull(request)) {
+            return false;
+        }
+
+        User findUser = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 유저입니다."));
+
+        Profile profile = request.toEntity();
+        findUser.updateProfile(profile);
+        return true;
+    }
+}

--- a/src/test/java/com/Bridge/bridge/controller/UserControllerTest.java
+++ b/src/test/java/com/Bridge/bridge/controller/UserControllerTest.java
@@ -1,0 +1,90 @@
+package com.Bridge.bridge.controller;
+
+import com.Bridge.bridge.domain.User;
+import com.Bridge.bridge.dto.request.UserFieldRequest;
+import com.Bridge.bridge.dto.request.UserProfileRequest;
+import com.Bridge.bridge.dto.request.UserRegisterRequest;
+import com.Bridge.bridge.dto.request.UserSignUpRequest;
+import com.Bridge.bridge.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("회원 가입시 유저 이름 등록")
+    void registerName() throws Exception {
+        //given
+        User newUser = new User("bridge@apple.com", "3d");
+        userRepository.save(newUser);
+
+        UserSignUpRequest request = new UserSignUpRequest("3d", "브릿지");
+
+        mockMvc.perform(post("/signup")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(1L))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("회원 가입시 관심 분야 및 프로필 등록")
+    void registerField() throws Exception {
+        //given
+        User newUser = new User("bridge@apple.com", "3d");
+        User saveUser = userRepository.save(newUser);
+
+        List<String> stack = new ArrayList<>();
+        stack.add("Spring");
+        stack.add("Java");
+        stack.add("Jpa");
+
+        UserProfileRequest profile = UserProfileRequest.builder()
+                .selfIntro("자기 소개서")
+                .career("대학생")
+                .stack(stack)
+                .build();
+
+        List<String> fields = new ArrayList<>();
+        fields.add("backend");
+        fields.add("frontend");
+        fields.add("designer");
+
+        UserFieldRequest field = new UserFieldRequest(fields);
+
+        UserRegisterRequest request = new UserRegisterRequest(saveUser.getId(), field, profile);
+
+
+        mockMvc.perform(post("/signup/info")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/Bridge/bridge/security/apple/ApplePublicKeysTest.java
+++ b/src/test/java/com/Bridge/bridge/security/apple/ApplePublicKeysTest.java
@@ -1,0 +1,38 @@
+package com.Bridge.bridge.security.apple;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+class ApplePublicKeysTest {
+
+    @Test
+    @DisplayName("alg, kid 값을 받아 일치하는 public key 반환")
+    void getMatchesKey() {
+        //given
+        ApplePublicKey expectedKey = new ApplePublicKey("kty", "kid", "use", "alg", "n", "e");
+        ApplePublicKeys applePublicKeys = new ApplePublicKeys(List.of(expectedKey));
+
+        //when
+        ApplePublicKey matchesKey = applePublicKeys.getMatchesKey("alg", "kid");
+
+        //then
+        assertEquals(expectedKey, matchesKey);
+    }
+
+    @Test
+    @DisplayName("일치하지 않아서 예외 반환")
+    void getException() {
+        //given
+        ApplePublicKey expectedKey = new ApplePublicKey("kty", "kid", "use", "alg", "n", "e");
+        ApplePublicKeys applePublicKeys = new ApplePublicKeys(List.of(expectedKey));
+
+        //expected
+        Assertions.assertThrows(IllegalArgumentException.class, () -> applePublicKeys.getMatchesKey("aaa", "bbb"));
+    }
+}

--- a/src/test/java/com/Bridge/bridge/service/AppleUtilsTest.java
+++ b/src/test/java/com/Bridge/bridge/service/AppleUtilsTest.java
@@ -1,0 +1,166 @@
+package com.Bridge.bridge.service;
+
+import com.Bridge.bridge.security.apple.ApplePublicKey;
+import com.Bridge.bridge.security.apple.ApplePublicKeys;
+import com.Bridge.bridge.security.apple.AppleUtils;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@SpringBootTest
+class AppleUtilsTest {
+
+    @Autowired
+    private AppleUtils appleUtils;
+
+    @Test
+    @DisplayName("토큰 헤더 파싱 확인")
+    void test() throws NoSuchAlgorithmException, IllegalAccessException {
+        //given
+        Date now = new Date();
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair();
+        PrivateKey privateKey = keyPair.getPrivate();
+
+        String idToken = Jwts.builder()
+                .setHeaderParam("kid", "W2R4HXF3K")
+                .claim("id", "12345678")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setExpiration(new Date(now.getTime() + 1000 * 60 * 60 * 24))
+                .signWith(SignatureAlgorithm.RS256, privateKey)
+                .compact();
+
+        //when
+        Map<String, String> header = appleUtils.parseHeaders(idToken);
+
+        //then
+        assertEquals(true, header.containsKey("alg"));
+        assertEquals(true, header.containsKey("kid"));
+        assertEquals("RS256", header.get("alg"));
+        assertEquals("W2R4HXF3K", header.get("kid"));
+    }
+
+    @Test
+    @DisplayName("이상한 토큰 헤더 파싱 시 예외 반환")
+    void test2() {
+        //expected
+        Assertions.assertThrows(IllegalAccessException.class, () -> appleUtils.parseHeaders("invalidToken"));
+    }
+
+    @Test
+    @DisplayName("퍼블릭 키로 복호화하여 payload 값 파싱")
+    void test3() throws Exception {
+        //given
+        Date now = new Date();
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair();
+        PrivateKey privateKey = keyPair.getPrivate();
+        PublicKey publicKey = keyPair.getPublic();
+
+        String idToken = Jwts.builder()
+                .setHeaderParam("kid", "W2R4HXF3K")
+                .claim("id", "12345678")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setExpiration(new Date(now.getTime() + 1000 * 60 * 60 * 24))
+                .signWith(SignatureAlgorithm.RS256, privateKey)
+                .compact();
+
+        //when
+        Claims claims = appleUtils.parsePublicKeyAndGetClaims(idToken, publicKey);
+
+        //then
+        assertEquals("12345678", claims.get("id"));
+        assertEquals("aud", claims.getAudience());
+        assertEquals("iss", claims.getIssuer());
+    }
+
+    @Test
+    @DisplayName("만료된 토큰 payload 값 파싱 시 예외 반환")
+    void test4() throws Exception{
+        //given
+        Date now = new Date();
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair();
+        PrivateKey privateKey = keyPair.getPrivate();
+        PublicKey publicKey = keyPair.getPublic();
+
+        String idToken = Jwts.builder()
+                .setHeaderParam("kid", "W2R4HXF3K")
+                .claim("id", "12345678")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setExpiration(new Date(now.getTime() - 1L))
+                .signWith(SignatureAlgorithm.RS256, privateKey)
+                .compact();
+
+        //expected
+        assertThrows(Exception.class, () -> appleUtils.parsePublicKeyAndGetClaims(idToken, publicKey));
+    }
+
+    @Test
+    @DisplayName("안맞는 키로 payload 값 파싱 시 예외 반환")
+    void test5() throws Exception{
+        //given
+        Date now = new Date();
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair();
+        KeyPair diffKeyPair = KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair();
+        PrivateKey privateKey = keyPair.getPrivate();
+        PublicKey publicKey = diffKeyPair.getPublic();
+
+        String idToken = Jwts.builder()
+                .setHeaderParam("kid", "W2R4HXF3K")
+                .claim("id", "12345678")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setExpiration(new Date(now.getTime() - 1L))
+                .signWith(SignatureAlgorithm.RS256, privateKey)
+                .compact();
+
+        //expected
+        assertThrows(Exception.class, () -> appleUtils.parsePublicKeyAndGetClaims(idToken, publicKey));
+    }
+
+    @Test
+    @DisplayName("애플 서버로 부터 Private Key 받아오기")
+    void test6() throws Exception {
+        //given
+        ApplePublicKeys publicKeys = appleUtils.getPublicKey();
+        List<ApplePublicKey> keys = publicKeys.getKeys();
+
+        //when
+        ApplePublicKey applePublicKey = keys.get(0);
+
+        //then
+        assertNotNull(applePublicKey.getKty());
+        assertNotNull(applePublicKey.getKid());
+        assertNotNull(applePublicKey.getUse());
+        assertNotNull(applePublicKey.getAlg());
+        assertNotNull(applePublicKey.getN());
+        assertNotNull(applePublicKey.getE());
+    }
+}

--- a/src/test/java/com/Bridge/bridge/service/AuthServiceTest.java
+++ b/src/test/java/com/Bridge/bridge/service/AuthServiceTest.java
@@ -1,0 +1,84 @@
+package com.Bridge.bridge.service;
+
+import com.Bridge.bridge.domain.User;
+import com.Bridge.bridge.dto.response.OAuthTokenResponse;
+import com.Bridge.bridge.dto.response.apple.AppleTokenResponse;
+import com.Bridge.bridge.repository.UserRepository;
+import com.Bridge.bridge.security.apple.AppleToken;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class AuthServiceTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @MockBean
+    private AppleToken appleToken;
+
+    @AfterEach
+    void clean() {
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("로그인 후 회원가입 - 처음 가입하는 경우")
+    void signup() {
+        //given
+        String email = "kyukyu@apple.com";
+        String platformId = "1";
+        String code = "12341234";
+
+        AppleTokenResponse response = new AppleTokenResponse("token", "access", 4, "refreshToken", "idToken");
+
+        when(appleToken.getAccessToken(any())).thenReturn(response);
+
+        //when
+        OAuthTokenResponse oAuthTokenResponse = authService.generateOAuthTokenResponse(email, platformId, code);
+
+        //then
+        assertEquals(1L, userRepository.count());
+        assertEquals("token", oAuthTokenResponse.getAccessToken());
+        assertEquals("kyukyu@apple.com", oAuthTokenResponse.getEmail());
+        assertEquals(false, oAuthTokenResponse.isRegistered());
+        assertEquals("1", oAuthTokenResponse.getPlatformId());
+    }
+
+    @Test
+    @DisplayName("로그인 후 회원가입 - 이미 가입한 경우")
+    void signup2() {
+        //given
+        String email = "kyukyu@apple.com";
+        String platformId = "1";
+        String code = "12341234";
+
+        userRepository.save(new User("kyukyu@apple.com", "1"));
+
+        AppleTokenResponse response = new AppleTokenResponse("token", "access", 4, "refreshToken", "idToken");
+
+        when(appleToken.getAccessToken(any())).thenReturn(response);
+
+        //when
+        OAuthTokenResponse oAuthTokenResponse = authService.generateOAuthTokenResponse(email, platformId, code);
+
+        //then
+        assertEquals(1L, userRepository.count());
+        assertEquals("token", oAuthTokenResponse.getAccessToken());
+        assertEquals("kyukyu@apple.com", oAuthTokenResponse.getEmail());
+        assertEquals(true, oAuthTokenResponse.isRegistered());
+        assertEquals("1", oAuthTokenResponse.getPlatformId());
+    }
+}

--- a/src/test/java/com/Bridge/bridge/service/UserServiceTest.java
+++ b/src/test/java/com/Bridge/bridge/service/UserServiceTest.java
@@ -1,0 +1,265 @@
+package com.Bridge.bridge.service;
+
+import com.Bridge.bridge.domain.User;
+import com.Bridge.bridge.dto.request.UserFieldRequest;
+import com.Bridge.bridge.dto.request.UserProfileRequest;
+import com.Bridge.bridge.dto.request.UserRegisterRequest;
+import com.Bridge.bridge.dto.request.UserSignUpRequest;
+import com.Bridge.bridge.dto.response.UserSignUpResponse;
+import com.Bridge.bridge.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+
+import javax.persistence.EntityNotFoundException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class UserServiceTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserService userService;
+
+    @BeforeEach
+    void clean() {
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("처음 로그인 시 이름 정보 등록")
+    void registerName() {
+        //given
+        User newUser = new User("kyukyu@apple.com", "3d");
+        userRepository.save(newUser);
+
+        UserSignUpRequest request = new UserSignUpRequest("3d", "브릿지");
+
+        //when
+        UserSignUpResponse response = userService.signUpName(request);
+
+        //then
+        assertEquals(1L, response.getUserId());
+        User user = userRepository.findAll().get(0);
+        assertEquals("브릿지", user.getName());
+    }
+
+    @Test
+    @DisplayName("처음 로그인 시 이름 정보 등록 - 예외 반환")
+    void registerNameEX() {
+        //given
+        User newUser = new User("kyukyu@apple.com", "3d");
+        userRepository.save(newUser);
+
+        UserSignUpRequest request = new UserSignUpRequest("3", "브릿지");
+
+        //expected
+        assertThrows(EntityNotFoundException.class, () -> userService.signUpName(request));
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("처음 로그인 시 개인 관심분야 등록")
+    void registerField() {
+        //given
+        User newUser = new User("kyukyu@apple.com", "3d");
+        User saveUser = userRepository.save(newUser);
+
+        List<String> fields = new ArrayList<>();
+        fields.add("backend");
+        fields.add("frontend");
+        fields.add("designer");
+
+        UserFieldRequest request = new UserFieldRequest(fields);
+
+        //when
+        userService.saveField(saveUser.getId(), request);
+
+        //then
+        User user = userRepository.findAll().get(0);
+        assertEquals(3, user.getFields().size());
+        assertEquals("frontend", user.getFields().get(1).getFieldName());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("처음 로그인 시 개인 관심분야 등록 - 아무것도 등록 안하는 경우")
+    void registerFieldEmpty() {
+        //given
+        User newUser = new User("kyukyu@apple.com", "3d");
+        User saveUser = userRepository.save(newUser);
+
+        List<String> fields = new ArrayList<>();
+
+        UserFieldRequest request = new UserFieldRequest(fields);
+
+        //when
+        userService.saveField(saveUser.getId(), request);
+
+        //then
+        User user = userRepository.findAll().get(0);
+        assertEquals(0, user.getFields().size());
+    }
+
+    @Test
+    @DisplayName("처음 로그인 시 개인 관심분야 등록 - 예외 반환")
+    void registerFieldEX() {
+        //given
+        User newUser = new User("kyukyu@apple.com", "3d");
+        User saveUser = userRepository.save(newUser);
+
+        List<String> fields = new ArrayList<>();
+        fields.add("backend");
+        fields.add("frontend");
+        fields.add("designer");
+
+        UserFieldRequest request = new UserFieldRequest(fields);
+
+        //expected
+        assertThrows(EntityNotFoundException.class, () -> userService.saveField(saveUser.getId() + 1L, request));
+    }
+
+
+    @Test
+    @Transactional
+    @DisplayName("처음 로그인 시 개인 프로필 등록")
+    void registerProfile() {
+        //given
+        User newUser = new User("kyukyu@apple.com", "3d");
+        User saveUser = userRepository.save(newUser);
+
+        List<String> stack = new ArrayList<>();
+        stack.add("Spring");
+        stack.add("Java");
+        stack.add("Jpa");
+
+        UserProfileRequest request = UserProfileRequest.builder()
+                .selfIntro("자기 소개서")
+                .career("대학생")
+                .stack(stack)
+                .build();
+
+        //when
+        userService.saveProfile(saveUser.getId(), request);
+
+        //then
+        User user = userRepository.findAll().get(0);
+        assertEquals("자기 소개서", user.getProfile().getSelfIntro());
+        assertEquals("대학생", user.getProfile().getCareer());
+        assertEquals(3, user.getProfile().getSkill().size());
+        assertEquals("Java", user.getProfile().getSkill().get(1));
+    }
+
+    @Test
+    @DisplayName("처음 로그인 시 개인 프로필 등록 - 예외반환")
+    void registerProfileEX() {
+        //given
+        User newUser = new User("kyukyu@apple.com", "3d");
+        User saveUser = userRepository.save(newUser);
+
+        List<String> stack = new ArrayList<>();
+        stack.add("Spring");
+        stack.add("Java");
+        stack.add("Jpa");
+
+        UserProfileRequest request = UserProfileRequest.builder()
+                .selfIntro("자기 소개서")
+                .career("대학생")
+                .stack(stack)
+                .build();
+
+        //expected
+        assertThrows(EntityNotFoundException.class, () -> userService.saveProfile(saveUser.getId()+1L, request));
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("유저 등록")
+    void register() {
+        //given
+        User newUser = new User("kyukyu@apple.com", "3d");
+        newUser.registerName("bridge");
+        User saveUser = userRepository.save(newUser);
+
+        List<String> stack = new ArrayList<>();
+        stack.add("Spring");
+        stack.add("Java");
+        stack.add("Jpa");
+
+        UserProfileRequest profile = UserProfileRequest.builder()
+                .selfIntro("자기 소개서")
+                .career("대학생")
+                .stack(stack)
+                .build();
+
+        List<String> fields = new ArrayList<>();
+        fields.add("backend");
+        fields.add("frontend");
+        fields.add("designer");
+
+        UserFieldRequest field = new UserFieldRequest(fields);
+
+        UserRegisterRequest request = new UserRegisterRequest(saveUser.getId(), field, profile);
+
+        //when
+        userService.signUpInfo(request);
+
+        //then
+        User user = userRepository.findAll().get(0);
+        assertEquals(3, user.getProfile().getSkill().size());
+        assertEquals(3, user.getFields().size());
+    }
+
+    @Test
+    @DisplayName("유저 등록 시 필드가 빈값인 경우")
+    void registerFieldNull() {
+        //given
+        User newUser = new User("kyukyu@apple.com", "3d");
+        newUser.registerName("bridge");
+        User saveUser = userRepository.save(newUser);
+
+        UserFieldRequest field = null;
+
+        UserRegisterRequest request = UserRegisterRequest.builder()
+                .userId(saveUser.getId())
+                .userField(field)
+                .build();
+
+        //when
+        boolean b = userService.saveField(request.getUserId(), request.getUserField());
+
+        //then
+        assertEquals(false, b);
+    }
+    @Test
+    @DisplayName("유저 등록 시 프로필이 빈 값인 경우")
+    void registerProfileNull() {
+        //given
+        User newUser = new User("kyukyu@apple.com", "3d");
+        newUser.registerName("bridge");
+        User saveUser = userRepository.save(newUser);
+
+        UserProfileRequest profile = null;
+
+        UserRegisterRequest request = UserRegisterRequest.builder()
+                .userId(saveUser.getId())
+                .userProfile(profile)
+                .build();
+
+        //when
+        boolean b = userService.saveProfile(request.getUserId(), request.getUserProfile());
+
+        //then
+        assertEquals(false, b);
+    }
+}


### PR DESCRIPTION
## Key Changes 🔑
<!-- 주요 구현 사항 -->
1. 로그인
- 애플 소셜 로그인 리팩토링
- 애플 소셜 로그인 테스트 (관련 로직만)

2. 회원 가입
- 소셜 로그인 후 고유 플램폼ID 와 Email 을 통해 가입 여부 판단 
   - 가입 전이라면 User 등록 후 엑세스 토큰 반환 -> 이름 및 프로필 정보 입력 받은 후 저장
   - 가입 한 사람은 그냥 엑세스 토큰 반환 후 끝

3. 이름 및 프로필 정보
- 이름 저장 로직과 프로필(관심분야 포함) 두가지로 나눠서 진행

## To Reviewers 🙌🏻
<!-- 리뷰어에게 전달할 말 -->
이름 저장과 프로필 두가지로 나눠 로직을 작성한 이유는 이름 같은 경우는 필수 입력 값이고, 관심 분야를 포함한 프로필 정보는 '건너뛰기'가 가능하기 때문에 두 기능을 분리 했습니다.

## PR Checklist ✔️
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요 -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.

