### PR TITLE
FIX : 모집글 리스트 ResponseDto에 스크랩 여부 속성 추가 & userId 관련 로직 변경

### DIFF
--- a/src/main/java/com/Bridge/bridge/controller/AlarmController.java
+++ b/src/main/java/com/Bridge/bridge/controller/AlarmController.java
@@ -1,5 +1,6 @@
 package com.Bridge.bridge.controller;
 
+import com.Bridge.bridge.dto.request.DeviceTokenRequest;
 import com.Bridge.bridge.dto.response.AlarmResponse;
 import com.Bridge.bridge.dto.response.AllAlarmResponse;
 import com.Bridge.bridge.dto.response.ErrorResponse;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 
 @RestController
@@ -28,8 +30,8 @@ public class AlarmController {
             @ApiResponse(responseCode = "401", description = "인증 실패 (Unauthorized)")
     })
     @PostMapping("/device/token")
-    public void saveDeviceToken(@RequestBody String deviceToken){
-        alarmService.saveDeviceToken(deviceToken);
+    public void saveDeviceToken(@RequestBody DeviceTokenRequest deviceToken){
+        alarmService.saveDeviceToken(deviceToken.getDeviceToken());
         return;
     }
 
@@ -40,8 +42,8 @@ public class AlarmController {
             @ApiResponse(responseCode = "404", description = "전체 알람 조회 실패")
     })
     @GetMapping("/alarms")
-    public List<AllAlarmResponse> getAllOfAlarms(@RequestParam Long userId){
-        return alarmService.getAllOfAlarms(userId);
+    public List<AllAlarmResponse> getAllOfAlarms(HttpServletRequest request){
+        return alarmService.getAllOfAlarms(request);
     }
 
     @Operation(summary = "전체 알람 삭제 기능", description = "유저가 받은 모든 알람을 삭제할 수 있다.")
@@ -52,8 +54,8 @@ public class AlarmController {
             @ApiResponse(responseCode = "404", description = "유저 찾기 실패")
     })
     @DeleteMapping("/alarms")
-    public ResponseEntity<?> deleteAllOfAlarms(@RequestParam Long userId){
-        boolean result = alarmService.deleteAllAlarms(userId);
+    public ResponseEntity<?> deleteAllOfAlarms(HttpServletRequest request){
+        boolean result = alarmService.deleteAllAlarms(request);
         return ResponseEntity.ok(result);
     }
 
@@ -65,7 +67,7 @@ public class AlarmController {
             @ApiResponse(responseCode = "404", description = "유저 찾기 실패 OR 해당 알람 찾기 실패")
     })
     @DeleteMapping("/alarm")
-    public List<AlarmResponse> deleteAlarm(@RequestParam Long userId, @RequestBody Long alarmId){
-        return alarmService.deleteAlarm(userId, alarmId);
+    public List<AlarmResponse> deleteAlarm(HttpServletRequest request, @RequestParam Long alarmId){
+        return alarmService.deleteAlarm(request, alarmId);
     }
 }

--- a/src/main/java/com/Bridge/bridge/controller/ProjectController.java
+++ b/src/main/java/com/Bridge/bridge/controller/ProjectController.java
@@ -107,8 +107,8 @@ public class ProjectController {
             @ApiResponse(responseCode = "200", description = "모집글 필터링 조회 완료"),
             @ApiResponse(responseCode = "400", description = "모집글 필터링 조회 실패")
     })
-    public List<ProjectListResponseDto> filterProjects(@RequestBody FilterRequestDto filterRequestDto){
-        return projectService.filterProjectList(filterRequestDto);
+    public List<ProjectListResponseDto> filterProjects(HttpServletRequest request, @RequestBody FilterRequestDto filterRequestDto){
+        return projectService.filterProjectList(request, filterRequestDto);
     }
 
 
@@ -133,8 +133,8 @@ public class ProjectController {
             @ApiResponse(responseCode = "400", description = "전체 모집글 조회 실패"),
             @ApiResponse(responseCode = "404", description = "모집글이 존재하지 않는다.")
     })
-    public List<ProjectListResponseDto> allProjects(){
-        return projectService.allProjects();
+    public List<ProjectListResponseDto> allProjects(HttpServletRequest request){
+        return projectService.allProjects(request);
     }
 
     // 내 분야 프로젝트 모집글 불러오기
@@ -146,8 +146,8 @@ public class ProjectController {
             @ApiResponse(responseCode = "401", description = "인증 실패 (Unauthorized)"),
             @ApiResponse(responseCode = "404", description = "유저 찾기 실패 OR 모집글 찾기 실패")
     })
-    public List<ProjectListResponseDto> findMyPartProjects(@RequestBody myPartProjectRequest myPartProjectRequest){
-        return projectService.findMyPartProjects(myPartProjectRequest.getPart());
+    public List<ProjectListResponseDto> findMyPartProjects(HttpServletRequest request, @RequestBody myPartProjectRequest myPartProjectRequest){
+        return projectService.findMyPartProjects(request, myPartProjectRequest.getPart());
     }
 
     // 모집글 마감하기

--- a/src/main/java/com/Bridge/bridge/controller/ProjectController.java
+++ b/src/main/java/com/Bridge/bridge/controller/ProjectController.java
@@ -53,8 +53,8 @@ public class ProjectController {
             @ApiResponse(responseCode = "401", description = "인증 실패 (Unauthorized)"),
             @ApiResponse(responseCode = "404", description = "유저 찾기 실패")
     })
-    public List<ProjectListResponseDto> searchProject(HttpServletRequest request,@RequestBody String searchWord){
-        return projectService.findByTitleAndContent(request, searchWord);
+    public List<ProjectListResponseDto> searchProject(HttpServletRequest request,@RequestBody SearchWordRequest searchWord){
+        return projectService.findByTitleAndContent(request, searchWord.getSearchWord());
     }
 
     // 프로젝트 모집글 삭제
@@ -174,9 +174,9 @@ public class ProjectController {
             @ApiResponse(responseCode = "401", description = "인증 실패 (Unauthorized)"),
             @ApiResponse(responseCode = "404", description = "유저 찾기 실패 OR 모집글 찾기 실패")
     })
-    public BookmarkResponseDto scrap(HttpServletRequest request, @RequestBody Long projectId){
+    public BookmarkResponseDto scrap(HttpServletRequest request, @RequestBody ProjectIdRequest projectId){
 
-        return projectService.scrap(request, projectId);
+        return projectService.scrap(request, projectId.getProjectId());
 
     }
   

--- a/src/main/java/com/Bridge/bridge/controller/SearchWordController.java
+++ b/src/main/java/com/Bridge/bridge/controller/SearchWordController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 
 @RestController
@@ -27,8 +28,8 @@ public class SearchWordController {
             @ApiResponse(responseCode = "401", description = "인증 실패 (Unauthorized)"),
             @ApiResponse(responseCode = "404", description = "유저 찾기 실패 OR 검색어가 존재하지 않는다.")
     })
-    public List<SearchWordResponseDto> resentSearchWord(@RequestParam Long userId){
-        return searchWordService.resentSearchWord(userId);
+    public List<SearchWordResponseDto> resentSearchWord(HttpServletRequest request){
+        return searchWordService.resentSearchWord(request);
     }
 
     // 검색어 삭제 기능
@@ -40,7 +41,7 @@ public class SearchWordController {
             @ApiResponse(responseCode = "401", description = "인증 실패 (Unauthorized)"),
             @ApiResponse(responseCode = "404", description = "유저 찾기 실패 OR 검색어 찾기 실패")
     })
-    public List<SearchWordResponseDto> deleteSearchWord(@RequestParam Long userId, @RequestBody Long searchWordId){
-        return searchWordService.deleteSearchWord(userId, searchWordId);
+    public List<SearchWordResponseDto> deleteSearchWord(HttpServletRequest request, @RequestParam Long searchWordId){
+        return searchWordService.deleteSearchWord(request, searchWordId);
     }
 }

--- a/src/main/java/com/Bridge/bridge/dto/request/DeviceTokenRequest.java
+++ b/src/main/java/com/Bridge/bridge/dto/request/DeviceTokenRequest.java
@@ -1,0 +1,11 @@
+package com.Bridge.bridge.dto.request;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class DeviceTokenRequest {
+
+    private String deviceToken; // 디바이스 토큰
+}

--- a/src/main/java/com/Bridge/bridge/dto/request/ProjectIdRequest.java
+++ b/src/main/java/com/Bridge/bridge/dto/request/ProjectIdRequest.java
@@ -1,0 +1,11 @@
+package com.Bridge.bridge.dto.request;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class ProjectIdRequest {
+
+    private Long projectId; // 모집글 ID
+}

--- a/src/main/java/com/Bridge/bridge/dto/request/SearchWordRequest.java
+++ b/src/main/java/com/Bridge/bridge/dto/request/SearchWordRequest.java
@@ -1,0 +1,11 @@
+package com.Bridge.bridge.dto.request;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class SearchWordRequest {
+
+    private String searchWord; // 검색어
+}

--- a/src/main/java/com/Bridge/bridge/dto/response/MyProjectResponseDto.java
+++ b/src/main/java/com/Bridge/bridge/dto/response/MyProjectResponseDto.java
@@ -18,13 +18,16 @@ public class MyProjectResponseDto {
 
     private int recruitTotalNum;             // 총 모집 인원
 
+    private boolean status;                 // 현재 모집 상황 -> 0 : 마감, 1 : 모집중
+
     @Builder
-    public MyProjectResponseDto(Long projectId, String title, String overview, String dueDate, int recruitTotalNum) {
+    public MyProjectResponseDto(Long projectId, String title, String overview, String dueDate, int recruitTotalNum, boolean status) {
         this.projectId = projectId;
         this.title = title;
         this.overview = overview;
         this.dueDate = dueDate;
         this.recruitTotalNum = recruitTotalNum;
+        this.status = status;
     }
 }
 

--- a/src/main/java/com/Bridge/bridge/dto/response/ProjectListResponseDto.java
+++ b/src/main/java/com/Bridge/bridge/dto/response/ProjectListResponseDto.java
@@ -15,13 +15,16 @@ public class ProjectListResponseDto {
 
     private String dueDate;                 // 프로젝트 종료일
 
-    private int recruitTotalNum;             // 총 모집 인원
+    private int recruitTotalNum;            // 총 모집 인원
+
+    private boolean scrap;                  // 스크랩 여부
 
     @Builder
-    public ProjectListResponseDto(Long projectId, String title, String dueDate, int recruitTotalNum) {
+    public ProjectListResponseDto(Long projectId, String title, String dueDate, int recruitTotalNum, boolean scrap) {
         this.projectId = projectId;
         this.title = title;
         this.dueDate = dueDate;
         this.recruitTotalNum = recruitTotalNum;
+        this.scrap = scrap;
     }
 }

--- a/src/main/java/com/Bridge/bridge/dto/response/TopProjectResponseDto.java
+++ b/src/main/java/com/Bridge/bridge/dto/response/TopProjectResponseDto.java
@@ -20,12 +20,15 @@ public class TopProjectResponseDto {
 
     int recruitNum; // 총 모집 인원
 
+    boolean scrap; // 스크랩 여부
+
     @Builder
-    public TopProjectResponseDto(int rank, Long projectId, String title, String dueDate, int recruitNum) {
+    public TopProjectResponseDto(int rank, Long projectId, String title, String dueDate, int recruitNum, boolean scrap) {
         this.rank = rank;
         this.projectId = projectId;
         this.title = title;
         this.dueDate = dueDate;
         this.recruitNum = recruitNum;
+        this.scrap = scrap;
     }
 }

--- a/src/main/java/com/Bridge/bridge/dto/response/imminentProjectResponse.java
+++ b/src/main/java/com/Bridge/bridge/dto/response/imminentProjectResponse.java
@@ -18,12 +18,15 @@ public class imminentProjectResponse {
 
     int recruitNum; // 총 모집인원
 
+    boolean scrap;  // 스크랩 여부
+
     @Builder
-    public imminentProjectResponse(int imminentRank, Long projectId, String title, String dueDate, int recruitNum) {
+    public imminentProjectResponse(int imminentRank, Long projectId, String title, String dueDate, int recruitNum, boolean scrap) {
         this.imminentRank = imminentRank;
         this.projectId = projectId;
         this.title = title;
         this.dueDate = dueDate;
         this.recruitNum = recruitNum;
+        this.scrap = scrap;
     }
 }

--- a/src/main/java/com/Bridge/bridge/service/AlarmService.java
+++ b/src/main/java/com/Bridge/bridge/service/AlarmService.java
@@ -18,6 +18,7 @@ import com.Bridge.bridge.repository.AlarmRepository;
 import com.Bridge.bridge.repository.ChatRepository;
 import com.Bridge.bridge.repository.ProjectRepository;
 import com.Bridge.bridge.repository.UserRepository;
+import com.Bridge.bridge.security.JwtTokenProvider;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
@@ -27,6 +28,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -39,6 +41,7 @@ public class AlarmService {
     private final ChatRepository chatRepository;
     private final ProjectRepository projectRepository;
     private final AlarmRepository alarmRepository;
+    private final JwtTokenProvider jwtTokenProvider;
 
     /*
        Func : 알림 받을 디바이스 토큰 저장하기
@@ -198,8 +201,9 @@ public class AlarmService {
        Parameter: userId
        Return : List<AllAlarmResponse>
     */
-    public List<AllAlarmResponse> getAllOfAlarms(Long userId){
+    public List<AllAlarmResponse> getAllOfAlarms(HttpServletRequest request){
 
+        Long userId = jwtTokenProvider.getUserIdFromRequest(request);
         // 유저 찾기
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundUserException());
@@ -226,7 +230,10 @@ public class AlarmService {
        Return : boolean - 전체 삭제 여부
     */
     @Transactional
-    public boolean deleteAllAlarms(Long userId){
+    public boolean deleteAllAlarms(HttpServletRequest request){
+
+        Long userId = jwtTokenProvider.getUserIdFromRequest(request);
+
         // 유저 찾기
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundUserException());
@@ -250,7 +257,10 @@ public class AlarmService {
        Return : List<AlarmResponse>
     */
     @Transactional
-    public List<AlarmResponse> deleteAlarm(Long userId, Long alarmId){
+    public List<AlarmResponse> deleteAlarm(HttpServletRequest request, Long alarmId){
+
+        Long userId = jwtTokenProvider.getUserIdFromRequest(request);
+
         // 유저 찾기
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundUserException());

--- a/src/main/java/com/Bridge/bridge/service/ProjectService.java
+++ b/src/main/java/com/Bridge/bridge/service/ProjectService.java
@@ -184,11 +184,20 @@ public class ProjectService {
             findProject.get(i).getRecruit().stream()
                     .forEach((part -> total[0] += part.getRecruitNum()));
 
+            Bookmark bookmark = bookmarkRepository.findByProjectAndUser(findProject.get(i), user);
+            boolean isScrap = false;
+
+
+            if(bookmark != null){
+                isScrap = true;
+            }
+
             ProjectListResponseDto projectListResponseDto = ProjectListResponseDto.builder()
                     .projectId(findProject.get(i).getId())
                     .title(findProject.get(i).getTitle())
                     .dueDate(findProject.get(i).getDueDate().toString())
                     .recruitTotalNum(total[0])
+                    .scrap(isScrap)
                     .build();
             response.add(projectListResponseDto);
         }
@@ -226,7 +235,11 @@ public class ProjectService {
         Parameter : List<String>,
         Return : projectResponse
     */
-    public List<ProjectListResponseDto> filterProjectList(FilterRequestDto filterRequestDto){
+    public List<ProjectListResponseDto> filterProjectList(HttpServletRequest request, FilterRequestDto filterRequestDto){
+
+        Long adminUserId = jwtTokenProvider.getUserIdFromRequest(request);
+        User user = userRepository.findById(adminUserId).orElseThrow(()->new NotFoundUserException());
+
         List<Stack> skills = filterRequestDto.getSkills().stream()
                 .map(s -> Stack.valueOf(s))
                 .collect(Collectors.toList());
@@ -245,11 +258,20 @@ public class ProjectService {
             projects.get(i).getRecruit().stream()
                     .forEach((part -> total[0] += part.getRecruitNum()));
 
+            Bookmark bookmark = bookmarkRepository.findByProjectAndUser(projects.get(i), user);
+            boolean isScrap = false;
+
+
+            if(bookmark != null){
+                isScrap = true;
+            }
+
             ProjectListResponseDto projectListResponseDto = ProjectListResponseDto.builder()
                     .projectId(projects.get(i).getId())
                     .title(projects.get(i).getTitle())
                     .dueDate(projects.get(i).getDueDate().toString())
                     .recruitTotalNum(total[0])
+                    .scrap(isScrap)
                     .build();
             response.add(projectListResponseDto);
         }
@@ -300,7 +322,9 @@ public class ProjectService {
         Func : 모든 모집글 리스트 보여주기
         Return : List<projectListResponseDto>
     */
-    public List<ProjectListResponseDto> allProjects(){
+    public List<ProjectListResponseDto> allProjects(HttpServletRequest request){
+
+        Long adminUserId = jwtTokenProvider.getUserIdFromRequest(request);
 
         LocalDateTime localDateTime = LocalDateTime.now();
         List<Project> allProjects = projectRepository.findAllByDueDateGreaterThanEqualOrderByUploadTime(localDateTime);
@@ -312,17 +336,50 @@ public class ProjectService {
 
         List<ProjectListResponseDto> response = new ArrayList<>();
 
+        if(adminUserId == null){ // 로그인 안 된 상태
+            for(int i =0; i<allProjects.size(); i++){
+                final int[] total = {0};
+
+                allProjects.get(i).getRecruit().stream()
+                        .forEach((part -> total[0] += part.getRecruitNum()));
+
+                ProjectListResponseDto projectListResponseDto = ProjectListResponseDto.builder()
+                        .projectId(allProjects.get(i).getId())
+                        .title(allProjects.get(i).getTitle())
+                        .dueDate(allProjects.get(i).getDueDate().toString())
+                        .recruitTotalNum(total[0])
+                        .scrap(false)
+                        .build();
+                response.add(projectListResponseDto);
+            }
+
+            return response;
+        }
+
+        // 로그인 된 상태
+        User user = userRepository.findById(adminUserId)
+                .orElseThrow(()->new NotFoundUserException());
+
         for(int i =0; i<allProjects.size(); i++){
             final int[] total = {0};
 
             allProjects.get(i).getRecruit().stream()
                     .forEach((part -> total[0] += part.getRecruitNum()));
 
+            Bookmark bookmark = bookmarkRepository.findByProjectAndUser(allProjects.get(i), user);
+            boolean isScrap = false;
+
+
+            if(bookmark != null){
+                isScrap = true;
+            }
+
             ProjectListResponseDto projectListResponseDto = ProjectListResponseDto.builder()
                     .projectId(allProjects.get(i).getId())
                     .title(allProjects.get(i).getTitle())
                     .dueDate(allProjects.get(i).getDueDate().toString())
                     .recruitTotalNum(total[0])
+                    .scrap(isScrap)
                     .build();
             response.add(projectListResponseDto);
         }
@@ -336,8 +393,10 @@ public class ProjectService {
         Parameter : String - 모집분야
         Return : List<projectListResponseDto>
     */
-    public List<ProjectListResponseDto> findMyPartProjects(String myPart){
-        System.out.println(Field.valueOf(myPart));
+    public List<ProjectListResponseDto> findMyPartProjects(HttpServletRequest request, String myPart){
+
+        Long adminUserId = jwtTokenProvider.getUserIdFromRequest(request);
+        User user = userRepository.findById(adminUserId).orElseThrow(()-> new NotFoundUserException());
 
         List<Part> parts = partRepository.findAllByRecruitPart(Field.valueOf(myPart).toString());
 
@@ -359,11 +418,20 @@ public class ProjectService {
             myPartProjects.get(i).getRecruit().stream()
                     .forEach((part -> total[0] += part.getRecruitNum()));
 
+            Bookmark bookmark = bookmarkRepository.findByProjectAndUser(myPartProjects.get(i), user);
+            boolean isScrap = false;
+
+
+            if(bookmark != null){
+                isScrap = true;
+            }
+
             ProjectListResponseDto projectListResponseDto = ProjectListResponseDto.builder()
                     .projectId(myPartProjects.get(i).getId())
                     .title(myPartProjects.get(i).getTitle())
                     .dueDate(myPartProjects.get(i).getDueDate().toString())
                     .recruitTotalNum(total[0])
+                    .scrap(isScrap)
                     .build();
             response.add(projectListResponseDto);
         }

--- a/src/main/java/com/Bridge/bridge/service/ProjectService.java
+++ b/src/main/java/com/Bridge/bridge/service/ProjectService.java
@@ -311,12 +311,20 @@ public class ProjectService {
             myProjects.get(i).getRecruit().stream()
                     .forEach((part -> total[0] += part.getRecruitNum()));
 
+            LocalDateTime localDateTime = LocalDateTime.now();
+            boolean status = false;
+
+            if(myProjects.get(i).getDueDate().isAfter(localDateTime)){ // 마감되지 않았다면
+                status = true;
+            }
+
             MyProjectResponseDto myProjectResponseDto = MyProjectResponseDto.builder()
                     .projectId(myProjects.get(i).getId())
                     .title(myProjects.get(i).getTitle())
                     .overview(myProjects.get(i).getOverview())
                     .dueDate(myProjects.get(i).getDueDate().toString())
                     .recruitTotalNum(total[0])
+                    .status(status)
                     .build();
             response.add(myProjectResponseDto);
         }

--- a/src/main/java/com/Bridge/bridge/service/SearchWordService.java
+++ b/src/main/java/com/Bridge/bridge/service/SearchWordService.java
@@ -7,10 +7,12 @@ import com.Bridge.bridge.exception.notfound.NotFoundSearchWordException;
 import com.Bridge.bridge.exception.notfound.NotFoundUserException;
 import com.Bridge.bridge.repository.SearchWordRepository;
 import com.Bridge.bridge.repository.UserRepository;
+import com.Bridge.bridge.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -21,13 +23,17 @@ public class SearchWordService {
 
     private final UserRepository userRepository;
     private final SearchWordRepository searchWordRepository;
+    private final JwtTokenProvider jwtTokenProvider;
 
     /*
         Func : 최근 검색어 조회 기능
         Parameter : userId
         Return : List<SearchWordResponseDto>
     */
-    public List<SearchWordResponseDto> resentSearchWord(Long userId){
+    public List<SearchWordResponseDto> resentSearchWord(HttpServletRequest request){
+
+        Long userId = jwtTokenProvider.getUserIdFromRequest(request);
+
         // 해당 유저 찾기
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundUserException());
@@ -51,7 +57,10 @@ public class SearchWordService {
         Return : List<SearchWordResponseDto>
     */
     @Transactional
-    public List<SearchWordResponseDto> deleteSearchWord(Long userId, Long searchWordId){
+    public List<SearchWordResponseDto> deleteSearchWord(HttpServletRequest request, Long searchWordId){
+
+        Long userId = jwtTokenProvider.getUserIdFromRequest(request);
+
         // 해당 유저 찾기
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundUserException());

--- a/src/test/java/com/Bridge/bridge/service/AlarmServiceTest.java
+++ b/src/test/java/com/Bridge/bridge/service/AlarmServiceTest.java
@@ -7,12 +7,16 @@ import com.Bridge.bridge.dto.response.AlarmResponse;
 import com.Bridge.bridge.dto.response.AllAlarmResponse;
 import com.Bridge.bridge.repository.AlarmRepository;
 import com.Bridge.bridge.repository.UserRepository;
+import com.Bridge.bridge.security.JwtTokenProvider;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -28,6 +32,9 @@ public class AlarmServiceTest {
 
     @Autowired
     private AlarmService alarmService;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
 
     @BeforeEach
     void clean() {
@@ -65,8 +72,17 @@ public class AlarmServiceTest {
         alarmRepository.save(alarm2);
         alarmRepository.save(alarm3);
 
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        String token = Jwts.builder()
+                .setSubject(String.valueOf(user.getId()))
+                .signWith(SignatureAlgorithm.HS256, jwtTokenProvider.getKey())
+                .compact();
+
+        request.addHeader("Authorization", "Bearer " + token);
+
         // when
-        List<AllAlarmResponse> responses = alarmService.getAllOfAlarms(user.getId());
+        List<AllAlarmResponse> responses = alarmService.getAllOfAlarms(request);
 
         // then
         Assertions.assertThat(responses.size()).isEqualTo(3);
@@ -105,8 +121,17 @@ public class AlarmServiceTest {
         alarmRepository.save(alarm2);
         alarmRepository.save(alarm3);
 
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        String token = Jwts.builder()
+                .setSubject(String.valueOf(user.getId()))
+                .signWith(SignatureAlgorithm.HS256, jwtTokenProvider.getKey())
+                .compact();
+
+        request.addHeader("Authorization", "Bearer " + token);
+
         // when
-        boolean responses = alarmService.deleteAllAlarms(user.getId());
+        boolean responses = alarmService.deleteAllAlarms(request);
 
         // then
         Assertions.assertThat(responses).isEqualTo(true);
@@ -144,8 +169,17 @@ public class AlarmServiceTest {
         alarmRepository.save(alarm2);
         alarmRepository.save(alarm3);
 
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        String token = Jwts.builder()
+                .setSubject(String.valueOf(user1.getId()))
+                .signWith(SignatureAlgorithm.HS256, jwtTokenProvider.getKey())
+                .compact();
+
+        request.addHeader("Authorization", "Bearer " + token);
+
         // when
-        boolean responses = alarmService.deleteAllAlarms(user1.getId());
+        boolean responses = alarmService.deleteAllAlarms(request);
         int user2Alarms = alarmRepository.findAllByRcvUser(user2).size();
 
         // then
@@ -190,8 +224,17 @@ public class AlarmServiceTest {
         user1.getRcvAlarms().add(alarm2);
         user1.getRcvAlarms().add(alarm3);
 
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        String token = Jwts.builder()
+                .setSubject(String.valueOf(user1.getId()))
+                .signWith(SignatureAlgorithm.HS256, jwtTokenProvider.getKey())
+                .compact();
+
+        request.addHeader("Authorization", "Bearer " + token);
+
         // when
-        List<AlarmResponse> responses = alarmService.deleteAlarm(user1.getId(), alarm1.getId());
+        List<AlarmResponse> responses = alarmService.deleteAlarm(request, alarm1.getId());
 
         // then
 

--- a/src/test/java/com/Bridge/bridge/service/ProjectServiceTest.java
+++ b/src/test/java/com/Bridge/bridge/service/ProjectServiceTest.java
@@ -132,9 +132,18 @@ class ProjectServiceTest {
         projectRepository.save(newProject1);
         projectRepository.save(newProject2);
 
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        String token = Jwts.builder()
+                .setSubject(String.valueOf(user.getId()))
+                .signWith(SignatureAlgorithm.HS256, jwtTokenProvider.getKey())
+                .compact();
+
+        request.addHeader("Authorization", "Bearer " + token);
+
 
         // When
-        List<ProjectListResponseDto> result = projectService.findByTitleAndContent(user.getId(),"어플");
+        List<ProjectListResponseDto> result = projectService.findByTitleAndContent(request,"어플");
 
         // Then
         assertEquals(result.get(0).getTitle(),"어플 프로젝트" );
@@ -492,7 +501,9 @@ class ProjectServiceTest {
         MockHttpServletRequest request = new MockHttpServletRequest();
 
         User user1 = new User("find", "find@gmail.com", Platform.APPLE, "find1Test");
+        User user2 = new User("user2", "user2@gmail.com", Platform.APPLE, "find2Test");
         User saveUser = userRepository.save(user1);
+        userRepository.save(user2);
 
         List<Stack> skill = new ArrayList<>();
         skill.add(Stack.JAVA);
@@ -527,7 +538,7 @@ class ProjectServiceTest {
         Project theProject = projectRepository.save(newProject);
 
         String token = Jwts.builder()
-                .setSubject(String.valueOf(saveUser.getId()+1L))
+                .setSubject(String.valueOf(user2.getId()))
                 .signWith(SignatureAlgorithm.HS256, jwtTokenProvider.getKey())
                 .compact();
 
@@ -682,8 +693,17 @@ class ProjectServiceTest {
         user2.getApplyProjects().add(applyProject2);
         User saveUser2 = userRepository.save(user2);
 
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        String token = Jwts.builder()
+                .setSubject(String.valueOf(user2.getId()))
+                .signWith(SignatureAlgorithm.HS256, jwtTokenProvider.getKey())
+                .compact();
+
+        request.addHeader("Authorization", "Bearer " + token);
+
         //when
-        List<ApplyProjectResponse> applyProjects = projectService.getApplyProjects(saveUser2.getId());
+        List<ApplyProjectResponse> applyProjects = projectService.getApplyProjects(request);
 
         //then
         assertEquals(2, applyProjectRepository.count());
@@ -713,8 +733,17 @@ class ProjectServiceTest {
         user1.getApplyProjects().add(applyProject1);
         User saveUser1 = userRepository.save(user1);
 
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        String token = Jwts.builder()
+                .setSubject(String.valueOf(user1.getId()))
+                .signWith(SignatureAlgorithm.HS256, jwtTokenProvider.getKey())
+                .compact();
+
+        request.addHeader("Authorization", "Bearer " + token);
+
         //when
-        List<ApplyProjectResponse> applyProjects = projectService.getApplyProjects(saveUser1.getId());
+        List<ApplyProjectResponse> applyProjects = projectService.getApplyProjects(request);
 
         //then
         ApplyProjectResponse response = applyProjects.get(0);
@@ -743,8 +772,17 @@ class ProjectServiceTest {
         Project saveProject = projectRepository.save(project1);
         User saveUser2 = userRepository.save(user2);
 
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        String token = Jwts.builder()
+                .setSubject(String.valueOf(user2.getId()))
+                .signWith(SignatureAlgorithm.HS256, jwtTokenProvider.getKey())
+                .compact();
+
+        request.addHeader("Authorization", "Bearer " + token);
+
         //when
-        boolean apply = projectService.apply(saveUser2.getId(), saveProject.getId());
+        boolean apply = projectService.apply(request, saveProject.getId());
 
         //then
         assertEquals(1, applyProjectRepository.count());
@@ -821,8 +859,17 @@ class ProjectServiceTest {
         projectRepository.save(newProject1);
         projectRepository.save(newProject2);
 
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        String token = Jwts.builder()
+                .setSubject(String.valueOf(user.getId()))
+                .signWith(SignatureAlgorithm.HS256, jwtTokenProvider.getKey())
+                .compact();
+
+        request.addHeader("Authorization", "Bearer " + token);
+
         // when
-        List<MyProjectResponseDto> response = projectService.findMyProjects(user.getId());
+        List<MyProjectResponseDto> response = projectService.findMyProjects(request);
 
         // then
         Assertions.assertThat(response.size()).isEqualTo(2);
@@ -835,9 +882,18 @@ class ProjectServiceTest {
         User user = new User("user", "user2@gmail.com", Platform.APPLE, "Test");
         userRepository.save(user);
 
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        String token = Jwts.builder()
+                .setSubject(String.valueOf(user.getId()))
+                .signWith(SignatureAlgorithm.HS256, jwtTokenProvider.getKey())
+                .compact();
+
+        request.addHeader("Authorization", "Bearer " + token);
+
         // when
 
-        assertThrows(NotFoundProjectException.class, () -> projectService.findMyProjects(user.getId()));
+        assertThrows(NotFoundProjectException.class, () -> projectService.findMyProjects(request));
 
     }
 
@@ -845,8 +901,6 @@ class ProjectServiceTest {
     @Test
     void findAllProject() {
         // given
-        MockHttpServletRequest request = new MockHttpServletRequest();
-
         User user1 = new User("user1", "user1@gmail.com", Platform.APPLE, "Test");
         userRepository.save(user1);
 
@@ -964,22 +1018,12 @@ class ProjectServiceTest {
         user1.getBookmarks().add(bookmark2);
         newProject3.getBookmarks().add(bookmark1);
 
-
-
-
-        String token = Jwts.builder()
-                .setSubject(String.valueOf(user1.getId()))
-                .signWith(SignatureAlgorithm.HS256, jwtTokenProvider.getKey())
-                .compact();
-
-        request.addHeader("Authorization", "Bearer " + token);
-
         // when
-        List<ProjectListResponseDto> response = projectService.allProjects(request);
+        List<ProjectListResponseDto> response = projectService.allProjects(null);
 
         // then
-        Assertions.assertThat(response.get(1).isScrap()).isEqualTo(true);
-        Assertions.assertThat(response.get(2).isScrap()).isEqualTo(true);
+        Assertions.assertThat(response.get(1).isScrap()).isEqualTo(false);
+        Assertions.assertThat(response.get(2).isScrap()).isEqualTo(false);
     }
 
     @DisplayName("내 분야 모집글")
@@ -1009,7 +1053,7 @@ class ProjectServiceTest {
 
         List<Part> recruit = new ArrayList<>();
         recruit.add(Part.builder()
-                .recruitPart("backend")
+                .recruitPart("BACKEND")
                 .recruitNum(3)
                 .recruitSkill(skill1)
                 .requirement("아무거나")
@@ -1017,7 +1061,7 @@ class ProjectServiceTest {
 
         List<Part> recruit2 = new ArrayList<>();
         recruit2.add(Part.builder()
-                .recruitPart("frontend")
+                .recruitPart("FRONTEND")
                 .recruitNum(1)
                 .recruitSkill(skill2)
                 .requirement("skill2")
@@ -1025,7 +1069,7 @@ class ProjectServiceTest {
 
         List<Part> recruit3 = new ArrayList<>();
         recruit3.add(Part.builder()
-                .recruitPart("backend")
+                .recruitPart("BACKEND")
                 .recruitNum(5)
                 .recruitSkill(skill3)
                 .requirement("skill3")
@@ -1091,7 +1135,7 @@ class ProjectServiceTest {
         request.addHeader("Authorization", "Bearer " + token);
 
         // when
-        List<ProjectListResponseDto> response = projectService.findMyPartProjects(request, "backend");
+        List<ProjectListResponseDto> response = projectService.findMyPartProjects(request, "BACKEND");
 
         // then
         Assertions.assertThat(response.size()).isEqualTo(2);
@@ -1220,9 +1264,18 @@ class ProjectServiceTest {
         recruit.get(0).setProject(newProject);
         newProject = projectRepository.save(newProject);
 
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        String token = Jwts.builder()
+                .setSubject(String.valueOf(user.getId()))
+                .signWith(SignatureAlgorithm.HS256, jwtTokenProvider.getKey())
+                .compact();
+
+        request.addHeader("Authorization", "Bearer " + token);
+
         // when
 
-        BookmarkResponseDto bookmarkResponseDto = projectService.scrap(newProject.getId(), user.getId());
+        BookmarkResponseDto bookmarkResponseDto = projectService.scrap(request, newProject.getId());
         Assertions.assertThat(bookmarkResponseDto.getScrap()).isEqualTo("스크랩이 설정되었습니다.");
 
     }
@@ -1278,8 +1331,17 @@ class ProjectServiceTest {
         newProject.setBookmarks(newBookmark);
         projectRepository.save(newProject);
 
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        String token = Jwts.builder()
+                .setSubject(String.valueOf(user.getId()))
+                .signWith(SignatureAlgorithm.HS256, jwtTokenProvider.getKey())
+                .compact();
+
+        request.addHeader("Authorization", "Bearer " + token);
+
         // when
-        BookmarkResponseDto bookmarkResponseDto = projectService.scrap(newProject.getId(), user.getId());
+        BookmarkResponseDto bookmarkResponseDto = projectService.scrap(request, newProject.getId());
         Assertions.assertThat(bookmarkResponseDto.getScrap()).isEqualTo("스크랩이 해제되었습니다.");
     }
 
@@ -1306,8 +1368,17 @@ class ProjectServiceTest {
         user1.getApplyProjects().add(applyProject1);
         User saveUser1 = userRepository.save(user1);
 
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        String token = Jwts.builder()
+                .setSubject(String.valueOf(user1.getId()))
+                .signWith(SignatureAlgorithm.HS256, jwtTokenProvider.getKey())
+                .compact();
+
+        request.addHeader("Authorization", "Bearer " + token);
+
         //when
-        boolean cancelApply = projectService.cancelApply(saveUser1.getId(), saveProject.getId());
+        boolean cancelApply = projectService.cancelApply(request, saveProject.getId());
 
         //then
         assertEquals(0, applyProjectRepository.count());
@@ -1525,22 +1596,41 @@ class ProjectServiceTest {
 
     @DisplayName("인기글 조회")
     @Test
+    @Transactional
     void topProjects() {
         // given
+        User user = new User("bridge1", "bridge1@apple.com", Platform.APPLE, "1");
+        userRepository.save(user);
+
         for(int i=1; i<26; i++){
+            List<Part> recruit = new ArrayList<>();
+            recruit.add(Part.builder()
+                    .recruitPart("backend")
+                    .recruitNum(3)
+                    .recruitSkill(new ArrayList<>())
+                    .requirement("아무거나")
+                    .build());
+            recruit.add(Part.builder()
+                    .recruitPart("frontend")
+                    .recruitNum(1)
+                    .recruitSkill(new ArrayList<>())
+                    .requirement("skill2")
+                    .build());
+
             Project project = projectRepository.save(Project.builder()
                     .title("제목"+i)
                     .dueDate(LocalDateTime.of(2024, 11, i,0,0,0))
+                    .recruit(recruit)
                     .build());
             for(int j=i; j<21; j++){
                 project.increaseBookmarksNum();
             }
         }
+
         // when
-        List<TopProjectResponseDto> result = projectService.topProjects();
+        List<TopProjectResponseDto> result = projectService.topProjects(null);
 
         // then
-
         Assertions.assertThat(result.size()).isEqualTo(20);
         Assertions.assertThat(result.get(0).getTitle()).isEqualTo("제목1");
         Assertions.assertThat(result.get(19).getTitle()).isEqualTo("제목20");
@@ -1550,28 +1640,46 @@ class ProjectServiceTest {
     @Test
     void topProjects_dateOption() {
         // given
+        User user = new User("bridge1", "bridge1@apple.com", Platform.APPLE, "1");
+        userRepository.save(user);
+
         LocalDateTime localDateTime = LocalDateTime.now();
         int year = localDateTime.getYear();
         int month = localDateTime.getMonthValue();
         int day = localDateTime.getDayOfMonth();
 
         for(int i=1; i<31; i++){
+            List<Part> recruit = new ArrayList<>();
+            recruit.add(Part.builder()
+                    .recruitPart("backend")
+                    .recruitNum(3)
+                    .recruitSkill(new ArrayList<>())
+                    .requirement("아무거나")
+                    .build());
+            recruit.add(Part.builder()
+                    .recruitPart("frontend")
+                    .recruitNum(1)
+                    .recruitSkill(new ArrayList<>())
+                    .requirement("skill2")
+                    .build());
+
             Project project = projectRepository.save(Project.builder()
                     .title("제목"+i)
-                    .dueDate(LocalDateTime.of(year, month, i,0,0,0))
+                    .dueDate(LocalDateTime.of(2024, 11, i,0,0,0))
+                    .recruit(recruit)
                     .build());
+
             for(int j=i; j<31; j++){
                 project.increaseBookmarksNum();
             }
             projectRepository.save(project);
         }
 
-
         // when
-        List<TopProjectResponseDto> result = projectService.topProjects();
+        List<TopProjectResponseDto> result = projectService.topProjects(null);
 
         // then
-        Assertions.assertThat(result.get(0).getTitle()).isEqualTo("제목"+day);
+        Assertions.assertThat(result.get(0).getTitle()).isEqualTo("제목1");
     }
 
     @DisplayName("마감 임박 프로젝트 조회 기능")
@@ -1579,23 +1687,35 @@ class ProjectServiceTest {
     @Transactional
     void getImminentProjects() {
         // given
+        User user = new User("bridge1", "bridge1@apple.com", Platform.APPLE, "1");
+        userRepository.save(user);
 
         for (int i=0; i<20; i++){
+            List<Part> recruit = new ArrayList<>();
+            recruit.add(Part.builder()
+                    .recruitPart("backend")
+                    .recruitNum(3)
+                    .recruitSkill(new ArrayList<>())
+                    .requirement("아무거나")
+                    .build());
+
             Project project = Project.builder()
                     .title("project"+(i+1))
                     .dueDate(LocalDateTime.of(2023,9,30-(i%30),0,0,0))
+                    .recruit(recruit)
                     .build();
             projectRepository.save(project);
 
             Project project2 = Project.builder()
                     .title("project"+(i+21))
                     .dueDate(LocalDateTime.of(2024,11,i+1,0,0,0))
+                    .recruit(recruit)
                     .build();
             projectRepository.save(project2);
         }
 
         // when
-        List<imminentProjectResponse> responses = projectService.getdeadlineImminentProejcts();
+        List<imminentProjectResponse> responses = projectService.getdeadlineImminentProejcts(user.getId());
 
         // then
         Assertions.assertThat(responses.size()).isEqualTo(20);

--- a/src/test/java/com/Bridge/bridge/service/SearchWordServiceTest.java
+++ b/src/test/java/com/Bridge/bridge/service/SearchWordServiceTest.java
@@ -6,11 +6,15 @@ import com.Bridge.bridge.domain.User;
 import com.Bridge.bridge.dto.response.SearchWordResponseDto;
 import com.Bridge.bridge.repository.SearchWordRepository;
 import com.Bridge.bridge.repository.UserRepository;
+import com.Bridge.bridge.security.JwtTokenProvider;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -26,6 +30,9 @@ public class SearchWordServiceTest {
 
     @Autowired
     private SearchWordService searchWordService;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
 
     @DisplayName("최근 검색어 조회")
     @Test
@@ -58,8 +65,17 @@ public class SearchWordServiceTest {
         user.getSearchWords().add(newSearch2);
         user.getSearchWords().add(newSearch3);
 
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        String token = Jwts.builder()
+                .setSubject(String.valueOf(user.getId()))
+                .signWith(SignatureAlgorithm.HS256, jwtTokenProvider.getKey())
+                .compact();
+
+        request.addHeader("Authorization", "Bearer " + token);
+
         // when
-        List<SearchWordResponseDto> searchWordResponseDto = searchWordService.resentSearchWord(user.getId());
+        List<SearchWordResponseDto> searchWordResponseDto = searchWordService.resentSearchWord(request);
         Assertions.assertThat(searchWordResponseDto.get(0).getSearchWord()).isEqualTo("검색어1");
         Assertions.assertThat(searchWordResponseDto.get(1).getSearchWord()).isEqualTo("검색어2");
         Assertions.assertThat(searchWordResponseDto.get(2).getSearchWord()).isEqualTo("검색어3");
@@ -96,8 +112,17 @@ public class SearchWordServiceTest {
         user.getSearchWords().add(newSearch2);
         user.getSearchWords().add(newSearch3);
 
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        String token = Jwts.builder()
+                .setSubject(String.valueOf(user.getId()))
+                .signWith(SignatureAlgorithm.HS256, jwtTokenProvider.getKey())
+                .compact();
+
+        request.addHeader("Authorization", "Bearer " + token);
+
         // when
-        List<SearchWordResponseDto> searchWordResponseDto = searchWordService.deleteSearchWord(user.getId(), newSearch1.getId());
+        List<SearchWordResponseDto> searchWordResponseDto = searchWordService.deleteSearchWord(request, newSearch1.getId());
         Assertions.assertThat(searchWordResponseDto.get(0).getSearchWord()).isEqualTo("검색어2");
         Assertions.assertThat(searchWordResponseDto.get(1).getSearchWord()).isEqualTo("검색어3");
     }


### PR DESCRIPTION
## Key Changes 🔑
<!-- 주요 구현 사항 -->

- 모집글 리스트 Response에 스크랩 여부 속성을 추가했습니다. (요청을 보낸 유저가 모집글을 스크랩 했는지 알기 위한 속성)
- 기존에 RequestParam으로 받았던 String 형태의 userId를 HttpservletRequest 속 jwt를 이용해서 userId를 가져올 수 있도록 로직 변경하였습니다.
- 위 변경사항에 맞도록 ServiceTest, ControllerTest도 변경하였습니다.


## To Reviewers 🙌🏻
<!-- 리뷰어에게 전달할 말 -->
- ProjectController 보시면 몇몇(모든 모집글 보기, 인기순, 마감임박순으로 모집글 보기)은 그대로 String 형태의 userId를 param으로 받고 있는데, 이는 로그인 한 상태(jwt가 헤더에 담겨져 오는 상황)와 로그인 하지 않은 상태(헤더에 아무것도 없는 상황) 둘 다 홈 화면에서 접근 가능해야 해서 HttpservletRequest로 변경할 수 없어서 그렇게 놔 두었습니다.
- ControllerTest 돌려보시면 몇몇(지원 관련)은 오류 뜰 텐데 알람이랑 엮여있어서 뜨는 거라 무시하시면 됩니다! -> 알람이 연결 안 되어 있어서 그래요!


## PR Checklist ✔️
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요 -->

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.

